### PR TITLE
fix: Allow runs stream to be sorted

### DIFF
--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -204,7 +204,10 @@ class RunsStream(AccountBasedIncrementalStream):
         start = self.get_starting_timestamp(context)
 
         if start:
+            # strip utc offset by removing timezone info - dbt Cloud API otherwise
+            # returns runs ignoring the range start time component (i.e. date only)
             start = start.replace(tzinfo=None).isoformat()
+
             end = datetime.datetime.max.replace(tzinfo=None).isoformat()
             params["finished_at__range"] = json.dumps([start, end])
 

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -196,17 +196,17 @@ class RunsStream(AccountBasedIncrementalStream):
             "artifacts_saved": record["artifacts_saved"],
         }
 
-    def get_url_params(self, context, next_page_token):
+    @override
+    def get_url_params(self, context: Context, next_page_token: int) -> dict:
         params = super().get_url_params(context, next_page_token)
-
-        start = self.get_starting_timestamp(context)
-        if start:
-            start = start.replace(tzinfo = None).isoformat()
-            end = datetime.datetime.max.replace(tzinfo = None).isoformat()
-            params["finished_at__range"] = json.dumps([start, end])
-
         params["order_by"] = "finished_at"
 
+        start = self.get_starting_timestamp(context)
+
+        if start:
+            start = start.replace(tzinfo=None).isoformat()
+            end = datetime.datetime.max.replace(tzinfo=None).isoformat()
+            params["finished_at__range"] = json.dumps([start, end])
 
         return params
 


### PR DESCRIPTION
Configuring the runs stream as sorted allows state to be incremented **during** the sync, rather than at the end (after all replication key values have been collected and compared).